### PR TITLE
if there is no file path use pwd to find tags file

### DIFF
--- a/ctags.lua
+++ b/ctags.lua
@@ -11,9 +11,6 @@ local function get_path(prefix, path)
 end
 
 local function find_tags(path)
-	if path == nil then
-		path = os.getenv('PWD') .. '/'
-	end
 	for i = #path, 1, -1 do
 		if path:sub(i, i) == '/' then
 			local prefix = path:sub(1, i)
@@ -171,9 +168,15 @@ local function pop_pos()
 	end
 end
 
+local function get_path()
+	if vis.win.file.path == nil then
+		return os.getenv('PWD') .. '/'
+	end
+	return vis.win.file.path
+end
+
 local function tag_cmd(tag)
-	local path = vis.win.file.path
-	local match = get_match(tag, path)
+	local match = get_match(tag, get_path())
 	if match == nil then
 		vis:info(string.format('Tag not found: %s', tag))
 	else
@@ -182,8 +185,7 @@ local function tag_cmd(tag)
 end
 
 local function tselect_cmd(tag)
-	local path = vis.win.file.path;
-	local matches = get_matches(tag, path)
+	local matches = get_matches(tag, get_path())
 	if matches == nil then
 		vis:info(string.format('Tag not found: %s', tag))
 	else

--- a/ctags.lua
+++ b/ctags.lua
@@ -11,6 +11,9 @@ local function get_path(prefix, path)
 end
 
 local function find_tags(path)
+	if path == nil then
+		path = os.getenv('PWD') .. '/'
+	end
 	for i = #path, 1, -1 do
 		if path:sub(i, i) == '/' then
 			local prefix = path:sub(1, i)


### PR DESCRIPTION
This allows the user to open vis with no file and use the :tag command to jump to a definition. This is helpful as there is no -t option to vis as there is for vim. It's not strictly necessary as any file can be opened (existing or not) but I find it useful.