### PR TITLE
Fix bug with absolute paths

### DIFF
--- a/ctags.lua
+++ b/ctags.lua
@@ -4,6 +4,10 @@ local positions = {}
 local tags = {'tags'}
 
 local function get_path(prefix, path)
+	if string.find(path, '^/') ~= nil then
+		return path, path
+	end
+
 	if string.find(path, '^./') ~= nil then
 		path = path:sub(3)
 	end


### PR DESCRIPTION
For example:
```sh
ctags -R . ~/a
```

Trying to resolve a token from `~/a` would try to open:
```sh
$PWD//home/$USER/a
```

When it should be:
```sh
/home/$USER/a
```