### PR TITLE
Format README for easier reading in $EDITOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # vis-ctags
+
 Basic ctags support for the [vis editor](https://github.com/martanne/vis).
 
 ## Usage
-The plugin should first of all be [enabled](https://github.com/martanne/vis/wiki/Plugins).
 
-| Action | Shortcut | Command |
-| --- | --- | --- |
-| Jump to tag | `Ctrl+]` | `tag <word>` |
+The plugin should first of all be
+[enabled](https://github.com/martanne/vis/wiki/Plugins).
+
+| Action           | Shortcut   | Command          |
+| ---------------- | ---------- | ---------------- |
+| Jump to tag      | `Ctrl+]`   | `tag <word>`     |
 | List tag matches | `g+Ctrl+]` | `tselect <word>` |
-| Jump back | `Ctrl+T` | `pop` |
+| Jump back        | `Ctrl+T`   | `pop`            |
 
-There may be some generic or language-specific issues. If you find one, or you have an idea of how to improve something, feel free to send a patch or create a pull request.
+There may be some generic or language-specific issues. If you find
+one, or you have an idea of how to improve something, feel free to
+send a patch or create a pull request.


### PR DESCRIPTION
Make some format changes in the README that make it much easier
to read in the terminal without affecting the markdown output.
Align the table and wrap lines.