### PR TITLE
Use quoted heredoc for safe shell usage

### DIFF
--- a/ctags.lua
+++ b/ctags.lua
@@ -224,8 +224,10 @@ local function tselect_cmd(tag, force)
 			table.insert(keys, matches[i].desc)
 		end
 
-		local command = string.format(
-			[[echo -e "%s" | vis-menu -p "Choose tag:"]], table.concat(keys, [[\n]]))
+		local command =
+			"vis-menu -p 'Choose tag:' << 'EOF'\n"..
+			table.concat(keys, '\n').."\n"..
+			"EOF"
 
 		local status, output =
 			vis:pipe(vis.win.file, {start = 0, finish = 0}, command)


### PR DESCRIPTION
The use of echo -e "%s" could cause several problems:

- echo -e is non standard and could behave differently in different
shells, or even in the same shell compiled with different options.

- By placing the filenames in double quotes any filename with a $
or ` in it could cause an expansion, including code injection if the
filename had $(...) or `...` in it.

Instead, concat with literal newlines (instead of \n which has to be
interpreted), and pass to vis-menu via a quoted heredoc (<< 'EOF'
instead of << EOF) so nothing can expand and everything is passed
literally. Note that this still won't work with filenames that contain
newlines, but I don't think ctags will either and I know vis-menu
won't, so that's not worth worrying about.