### PR TITLE
Export actions for mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Basic ctags support for the [vis editor](https://github.com/martanne/vis).
 The plugin should first of all be
 [enabled](https://github.com/martanne/vis/wiki/Plugins).
 
-| Action           | Shortcut   | Command          |
-| ---------------- | ---------- | ---------------- |
-| Jump to tag      | `Ctrl+]`   | `tag <word>`     |
-| List tag matches | `g+Ctrl+]` | `tselect <word>` |
-| Jump back        | `Ctrl+T`   | `pop`            |
+| Action           | Shortcut   | Command          | Exports            |
+| ---------------- | ---------- | ---------------- | ------------------ |
+| Jump to tag      | `Ctrl+]`   | `tag <word>`     | `actions.tag`      |
+| List tag matches | `g+Ctrl+]` | `tselect <word>` | `actions.tselect`  |
+| Jump back        | `Ctrl+T`   | `pop`            | `actions.pop`      |
 
 There may be some generic or language-specific issues. If you find
 one, or you have an idea of how to improve something, feel free to

--- a/ctags.lua
+++ b/ctags.lua
@@ -2,6 +2,7 @@ require('vis')
 
 local positions = {}
 local tags = {'tags'}
+local ctags = { actions = {} }
 
 local function abs_path(prefix, path)
 	if string.find(path, '^/') ~= nil then
@@ -271,25 +272,33 @@ vis:option_register("tags", "string", function(value)
 	end
 end, 'Paths to search for tags (separated by spaces)')
 
-vis:map(vis.modes.NORMAL, '<C-]>', function(keys)
+ctags.actions.tag = function(keys)
 	local query = get_query()
 	local force = false
 	if query ~= nil then
 		tag_cmd(query, force)
 	end
 	return 0
-end)
+end
 
-vis:map(vis.modes.NORMAL, 'g<C-]>', function(keys)
+ctags.actions.tselect = function(keys)
 	local query = get_query()
 	local force = false
 	if query ~= nil then
 		tselect_cmd(query, force)
 	end
 	return 0
-end)
+end
 
-vis:map(vis.modes.NORMAL, '<C-t>', function(keys)
+ctags.actions.pop = function(keys)
 	pop_pos()
 	return 0
-end)
+end
+
+vis:map(vis.modes.NORMAL, '<C-]>', ctags.actions.tag)
+
+vis:map(vis.modes.NORMAL, 'g<C-]>', ctags.actions.tselect)
+
+vis:map(vis.modes.NORMAL, '<C-t>', ctags.actions.pop)
+
+return ctags


### PR DESCRIPTION
Export the following actions for mapping: `jump_to_tag`, `list_tag_matches`, and `jump_back`.

Added a new column `Exports` to usages in `README.md`.

Solves #12 