### PR TITLE
Quote filename in goto_pos

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -160,7 +160,7 @@ end
 ]]
 local function goto_pos(pos, force)
 	if pos.path ~= vis.win.file.path then
-		vis:command(string.format(force and 'e! %s' or 'e %s', pos.path))
+		vis:command(string.format(force and 'e! "%s"' or 'e "%s"', pos.path))
 		if pos.path ~= vis.win.file.path then
 			return false
 		end


### PR DESCRIPTION
Currently, opening the file breaks if there is a space in the path somewhere -- without this change pressing `Ctrl + ]` to navigate to a different file with a space in the path (ie. `./Online Task 2/src/Athlete.java`) fails with the message "Only 1 filename allowed".

It's possible there are other places that might need quoting, I only did a quick look for where the file was being opened :)