### PR TITLE
Fix the inability to jump back after going to a symlinked file

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -161,7 +161,11 @@ end
 local function goto_pos(pos, force)
 	if pos.path ~= vis.win.file.path then
 		vis:command(string.format(force and 'e! "%s"' or 'e "%s"', pos.path))
-		if pos.path ~= vis.win.file.path then
+		local h = io.popen(string.format('test %s -ef %s && echo "yes"',
+			pos.path, vis.win.file.path));
+		local same = h:read()
+		h:close()
+		if same ~= "yes" and pos.path ~= vis.win.file.path then
 			return false
 		end
 	end


### PR DESCRIPTION
When jumping to a tag that is present in a symlinked file, the path
being set in vis may not match the path stored in the tags file.
This will result in being unable to jump back because of the condition.
This commit uses the test command to resolve this; the flag '-ef'
isn't standard but commonly implemented in BSDs and Linux.
If you have OS X, Solaris, AIX... you may run into some difficulties
where the fallback behaviour will be handy.

Signed-off-by: Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>