### PR TITLE
Ignore directories named "tags"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,16 @@ local function abs_path(prefix, path)
 	return prefix .. path, path
 end
 
+local function is_directory(path)
+	local dir = io.open(path..'/', 'r')
+	if dir then
+		dir:close()
+		return true
+	else
+		return false
+	end
+end
+
 local function find_tags(path)
 	for i = #path, 1, -1 do
 		if path:sub(i, i) == '/' then
@@ -28,7 +38,7 @@ local function find_tags(path)
 				else
 					filename = prefix .. tagfile
 				end
-				if not os.rename(filename..'/', filename..'/') then
+				if not is_directory(filename) then
 					local file = io.open(filename, 'r')
 
 					if file ~= nil then

--- a/init.lua
+++ b/init.lua
@@ -28,10 +28,12 @@ local function find_tags(path)
 				else
 					filename = prefix .. tagfile
 				end
-				local file = io.open(filename, 'r')
+				if not os.rename(filename..'/', filename..'/') then
+					local file = io.open(filename, 'r')
 
-				if file ~= nil then
-					return file, prefix
+					if file ~= nil then
+						return file, prefix
+					end
 				end
 			end
 		end


### PR DESCRIPTION
It was getting confused if there was a directory named "tags" somewhere in the search path before the actual tags file, because it can open it as a file, but can't read from it (at least on Linux).

Since there is no way in standard Lua to check if some path is a directory, it tries to rename the file with a `/` appended to itself, which should work only for directories in any Unix-like OS.