### PR TITLE
Fix bug where completions error out of if no tag matches are found

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -325,8 +325,11 @@ local function complete()
 		table.insert(candidates, file:content(sel.range))
 	end
 	vis:feedkeys('<Escape><Escape><vis-selections-restore>')
-	for idx, match in pairs(get_matches(prefix, win_path(), true)) do
-		table.insert(candidates, match.tag)
+	local matches = get_matches(prefix, win_path(), true)
+	if matches then
+		for idx, match in pairs(matches) do
+			table.insert(candidates, match.tag)
+		end
 	end
 	if #candidates == 1 and candidates[1] == '\n' then
 		return


### PR DESCRIPTION
There was a bug where if no matches were found during a completion the editor would throw an error trying to iterate over a nil list.
